### PR TITLE
Remove INN/client-hosting-manager from the submodules list

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,6 @@ Using `sitename.org` as an example, and providing full pathnames in front of com
 		new file:   fabfile.py
 		new file:   requirements.txt
 		new file:   tools
-		new file:   wp-content/plugins/client-hosting-manager
 		new file:   wp-content/themes/largo
 
 	```
@@ -71,3 +70,5 @@ Using `sitename.org` as an example, and providing full pathnames in front of com
 
 
 This doesn't set any variables. This doesn't fill out any text. This just gets you the files.
+
+If this repo is hosted on an account owned by INN, add [client-hosting-manager](https://github.com/INN/client-hosting-manager) as a submodule in `wp-content/plugins/client-hosting-manager`, and add the required constants to the site's wp-config.php after deploying, but before activating.

--- a/initialize.sh
+++ b/initialize.sh
@@ -31,11 +31,7 @@ mkdir -p wp-content/themes/
 rm -r wp-content/themes/largo
 git submodule add -f git@github.com:INN/Largo.git wp-content/themes/largo
 
-# add INN's hosting management plugin as a must-use plugin
-# https://github.com/INN/client-hosting-manager
 mkdir -p wp-content/plugins/
-rm -r wp-content/plugins/client-hosting-manager
-git submodule add -f git@github.com:INN/client-hosting-manager.git wp-content/plugins/client-hosting-manager
 
 # Move readme-template.md over README.md
 if [ -f "readme-template.md" ]


### PR DESCRIPTION
## Changes

- Removes https://github.com/INN/client-hosting-manager from the list of automatically-generated submodules
- Adds note about adding CHM to the bottom of the setup docs

## Why

Because CHM is a plugin that is only needed when we're hosting a particular umbrella repo on our own hosting, and for most new umbrella repos we're creating that is not the case.