### PR TITLE
Change initialize.sh to use https instead of git path for Largo, 

### DIFF
--- a/initialize.sh
+++ b/initialize.sh
@@ -25,7 +25,7 @@ cd `git rev-parse --show-toplevel`
 # add Largo at master, overriding the .gitignore on wp-content
 mkdir -p wp-content/themes/
 rm -r wp-content/themes/largo
-git submodule add -f git@github.com:INN/Largo.git wp-content/themes/largo
+git submodule add -f https://github.com/INN/largo.git wp-content/themes/largo
 
 mkdir -p wp-content/plugins/
 


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Replaces the `git://` URL for the Largo submodule with an `https://` URL.

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
because WPE can't check out GitHub git:// urls

## Testing/Questions

Features that this PR affects:

- git deploys 

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?
- [ ] 

Steps to test this PR:

1. check if the submodule URL change in https://github.com/INN/umbrella-caribbean/commit/4eb0cc777ceadc464a7cf70f4332b740a775242c works
