### PR TITLE
Switch to Largo's release branch, rather than whatever the repo says is default 

### DIFF
--- a/initialize.sh
+++ b/initialize.sh
@@ -18,14 +18,16 @@
 # A: No. They're currently just checked out at the tip of the master branch.
 #    It's assumed that if you're setting up boilerplate, you're going to check
 #    out a needed commit yourself.
+# A: For Largo, kinda. It chooses the latest commit in the 'release' branch,
+#    which is usually only pushed to when making a new release.
 
 # make sure we're in the top level of the git repository
 cd `git rev-parse --show-toplevel`
 
-# add Largo at master, overriding the .gitignore on wp-content
+# add Largo at release, using -f to overriding the .gitignore on wp-content
 mkdir -p wp-content/themes/
 rm -r wp-content/themes/largo
-git submodule add -f https://github.com/INN/largo.git wp-content/themes/largo
+git submodule add -b release -f https://github.com/INN/largo.git wp-content/themes/largo
 
 mkdir -p wp-content/plugins/
 


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Switches to the `release` branch of Largo. https://github.com/INN/largo/tree/release

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->

Using the 'release' branch because I'm not aware of a way to tell git "use the latest tag" without using a lot of bashisms to get the latest tag and then use that tag as the checkout point.

<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
Resolves #6.

## Testing/Questions

Features that this PR affects:

- new-repo setup

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Is this PR targeting the correct branch in this repository?
- [ ] 

Steps to test this PR:

1. In a new folder, clone this repo
2. Run the initialization script
3. See what branch of Largo is checked out.